### PR TITLE
Attempting to fix alt-tab bug in bqt

### DIFF
--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -44,6 +44,7 @@ class BlenderApplication(QApplication):
 
         # Runtime
         self._set_window_geometry()
+        self.just_focused = False
         self.focusObjectChanged.connect(self._on_focus_object_changed)
 
     @abstractstaticmethod

--- a/bqt/blender_applications/darwin_blender_application.py
+++ b/bqt/blender_applications/darwin_blender_application.py
@@ -81,3 +81,4 @@ class DarwinBlenderApplication(BlenderApplication):
 
         if focus_object is self.blender_widget:
             self._ns_window.makeKey()
+            self.just_focused = True

--- a/bqt/blender_applications/win32_blender_application.py
+++ b/bqt/blender_applications/win32_blender_application.py
@@ -47,3 +47,4 @@ class Win32BlenderApplication(BlenderApplication):
 
         if focus_object is self.blender_widget:
             win32gui.SetFocus(self._hwnd)
+            self.just_focused = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fake-bpy-module-2.80
 PySide2
 pypiwin32
+keyboard


### PR DESCRIPTION
Currently there is a bug in bqt, if you alt-tab out of Blender and back in, it will often perceive that the alt key is stuck. The same can happen with the shift or ctrl key (but alt-tab is the most common use-case where the bug becomes apparent).

I'm attempting a fix that catches at least some cases of this behavior by running a second operator along side the QOperator. The second operator is a regular Blender operator running modally and scanning inputs. I've also added a just_focused property on the BlenderApplication object, that we can check if - "Blender just got focused" (came back from Alt-Tab). In that case the modal operator will check if there's a keyboard event perceived and if that keyboard event contained any modifier key. We then simply send an emulated key release to the operating system.

Apparently Blender having trouble catching if any modifier keys have been released is not a new issue by bqt, but appears to be more common with bqt. E.g. see the following two older issues:
https://developer.blender.org/T52905
https://developer.blender.org/T64105