### PR TITLE
Small fix to check if bqt is installed to Blender

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,11 @@ class CustomInstall(install):
 
         # Get the file destination path
         destination_path = Path(sys.executable).parents[2] / "scripts" / "startup"
+
+        if not os.path.exists(destination_path) and not os.path.isdir(destination_path):
+            print("Bqt didn't get installed in a Blender Python environment, skipping further setup.")
+            return
+
         # Copy the file to destination path
         copy(startup_file_path, destination_path)
 


### PR DESCRIPTION
This Pull Request checks if the 'scripts/startup' location exists during the setup of bqt and returns early if it doesn't to avoid breaking the pip installation in case the user installs bqt to a non-Blender python environment (e.g. a virtual environment outside of Blender).