### PR TITLE
Fix alt tab by not embedding blender window in qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ from bqt import hello_world
 hello_world.demo()
 ```  
 
+#### Environment Variables
+env variables and their default values:
+```python
+BQT_DISABLE_STARTUP = None  #  test
+BQT_TICK_RATE = 30          # 30 ticks per second by default for the qt event loop
+BQT_FROM_WIN_ID = False     # if true, blender will be wrapped in a qt window. 
+                            # disabled since it causes alt tab bugs, breaking typing in blender
+```
 ## Contribute
 If you would like to contribute to bqt, please create a pull request and we will review
 the changes

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -3,13 +3,26 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
-
+import os
 from abc import abstractmethod, abstractstaticmethod, ABCMeta
 from pathlib import Path
 
-from PySide2.QtWidgets import QApplication, QWidget
-from PySide2.QtGui import QCloseEvent, QIcon, QImage, QPixmap, QWindow
-from PySide2.QtCore import QEvent, QObject, QRect, QSettings
+import Qt5
+QApplication = Qt5.QtWidgets.QApplication
+QWidget = Qt5.QtWidgets.QWidget
+QCloseEvent = Qt5.QtGui.QCloseEvent
+QIcon = Qt5.QtGui.QIcon
+QImage = Qt5.QtGui.QImage
+QPixmap = Qt5.QtGui.QPixmap
+QWindow = Qt5.QtGui.QWindow
+QEvent = Qt5.QtCore.QEvent
+QObject = Qt5.QtCore.QObject
+QRect = Qt5.QtCore.QRect
+QSettings = Qt5.QtCore.QSettings
+
+# from Qt5.QtWidgets import QApplication, QWidget
+# from Qt5.QtGui import QCloseEvent, QIcon, QImage, QPixmap, QWindow
+# from Qt5.QtCore import QEvent, QObject, QRect, QSettings
 
 
 class BlenderApplication(QApplication):
@@ -17,9 +30,9 @@ class BlenderApplication(QApplication):
     Base Implementation for QT Blender Window Container
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         __metaclass__ = ABCMeta
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         self._stylesheet_filepath = Path(__file__).parent / ".." / "blender_stylesheet.qss"
         self._settings_key_geometry = "Geometry"
@@ -35,15 +48,24 @@ class BlenderApplication(QApplication):
 
         # Blender Window
         self._hwnd = self._get_application_hwnd()
-        self._blender_window = QWindow.fromWinId(self._hwnd)
+
+        # since embedding window messes with alt tabbing, we don't embed by default
+        embed_window = os.getenv("BQT_FROM_WIN_ID", False)
+        if embed_window:
+            self._blender_window = QWindow.fromWinId(self._hwnd)
+        else:
+            self._blender_window = QWindow()
+
         self.blender_widget = QWidget.createWindowContainer(self._blender_window)
-        self.blender_widget.setWindowTitle("Blender")
+        self.blender_widget.setWindowTitle("Blender Qt")
 
         # Variables
         self.should_close = False
 
         # Runtime
-        self._set_window_geometry()
+        self.just_focused = False
+        if embed_window:
+            self._set_window_geometry()  # apply window size settings from last session
         self.focusObjectChanged.connect(self._on_focus_object_changed)
 
     @abstractstaticmethod


### PR DESCRIPTION
this PR is the "final" PR that fixes the alt tab issues bqt caused, making blender absolutely useless.
without this IMO bqt is not production ready.

the alt tab issues happened when we wrapped blender in a qt window.
however, the main purpose of bqt is to support qt in blender.
this PR deliveres on that core promise, at the cost of removing wrapping the blender window.
this means that qt windows are not always on top.
but your qt app will work without requiring any special qt setup, and wont bug when alt tabbing.

an optional ENV variable let's you re-enable the window wrapping again. (which ofcourse re-introduces the alt tab bug)

it depends on previous PRs which should be merged in first.
- [support qt5](https://github.com/techartorg/bqt/pull/25)
- [pass sys args to QApplication](https://github.com/techartorg/bqt/pull/26)
