### PR TITLE
match LICENSE with the github version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,3 @@
-Blender is a registered trademark (®) of the Blender Foundation in EU and USA.
-The Blender logo itself is a property of the Blender Foundation.
-
-
-
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
currently license does not show in github sidebar
<img width="287" alt="image" src="https://user-images.githubusercontent.com/3758308/192225895-4846c5ce-d0ea-489d-8ca0-7231ad158e5a.png">


this PR proposes to use the standardised MPL license, which is identical in licensing terms.
the only difference is that the current one mentions Blender is a trademarked property.
```
Blender is a registered trademark (®) of the Blender Foundation in EU and USA.
The Blender logo itself is a property of the Blender Foundation.
```
AFAIK there is no requirement for blender scripts to mention that in every license.

when removed it is instantly clear to the user which license we are using:
<img width="329" alt="image" src="https://user-images.githubusercontent.com/3758308/192225470-91aa47e0-a440-4cc7-b3bd-c82795c53444.png">
