### PR TITLE
add dpi scale support

### DIFF
--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 import bpy
-
+import PySide2.QtCore as QtCore
 from PySide2.QtWidgets import QApplication
 
 from .blender_applications import BlenderApplication
@@ -51,6 +51,10 @@ def instantiate_application() -> BlenderApplication:
     Returns BlenderApplication: Application Instance
 
     """
+    # enable dpi scale, run before creating QApplication
+    QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+    QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
     app = QApplication.instance()
     if not app:
         app = load_os_module()


### PR DESCRIPTION
<img width="350" alt="image" src="https://user-images.githubusercontent.com/3758308/193150169-fca6185d-8561-444c-bfdd-397a56b3476a.png">

bar is very small on 4k monitor when using 150% zoom
dpi scaling set to passthrough fixes this