### PR TITLE
Resize window

### DIFF
--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -5,7 +5,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
 import bqt
 import bqt.focus
-# import atexit
 import os
 import sys
 import bpy
@@ -113,8 +112,6 @@ def register():
 
     create_global_app()
 
-    # atexit.register(on_exit)
-
 
 def unregister():
     """
@@ -127,18 +124,7 @@ def unregister():
     #  for now we just return since unregister should not be called partially
     return
 
-    if not os.getenv("BQT_DISABLE_WRAP", 0) == "1":
-        bpy.utils.unregister_class(bqt.focus.QFocusOperator)
-    # atexit.unregister(on_exit)
-
-
-# todo this doesnt work, likely becayse of the ACCESS_VIOLATION
-# def on_exit():
-#     """Close BlenderApplication instance on exit"""
-#     print("bqt: on_exit")
-#     app = QApplication.instance()
-#     if app:
-#         app.store_window_geometry()
-#         app.quit()
+    # if not os.getenv("BQT_DISABLE_WRAP", 0) == "1":
+    #     bpy.utils.unregister_class(bqt.focus.QFocusOperator)
 
 

--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -51,34 +51,29 @@ def instantiate_application() -> "bqt.blender_applications.BlenderApplication":
     return app
 
 
-def load_os_module() -> object:
-    """
-    Loads the correct OS platform Application Class
-
-    Returns: Instance of BlenderApplication
-
-    """
+def load_os_module() -> "bqt.blender_applications.BlenderApplication":
+    """Loads the correct OS platform Application Class"""
     operating_system = sys.platform
     if operating_system == "darwin":
         from .blender_applications.darwin_blender_application import DarwinBlenderApplication
 
         return DarwinBlenderApplication(sys.argv)
+
     if operating_system in ["linux", "linux2"]:
         # TODO: LINUX module
         pass
+
     elif operating_system == "win32":
         from .blender_applications.win32_blender_application import Win32BlenderApplication
 
         return Win32BlenderApplication(sys.argv)
 
 
-parent_window = None
-
-
 @bpy.app.handlers.persistent
 def create_global_app():
     """
-    runs after blender finished startup
+    Create a global QApplication instance, that's maintained between Blender sessions.
+    Runs after Blender finished startup.
     """
     # global qapp
     qapp = instantiate_application()
@@ -92,6 +87,7 @@ def create_global_app():
 
 def register():
     """
+    Runs on enabling the add-on.
     setup bqt, wrap blender in qt, register operators
     """
 
@@ -115,10 +111,7 @@ def register():
 
 def unregister():
     """
-    Unregister Blender Operator classes
-
-    Returns: None
-
+    Runs on disabling the add-on.
     """
     # todo, as long as blender is wrapped in qt, unregistering operator & callback will cause issues,
     #  for now we just return since unregister should not be called partially

--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -5,7 +5,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
 import bqt
 import bqt.focus
-import atexit
+# import atexit
 import os
 import sys
 import bpy
@@ -113,7 +113,7 @@ def register():
 
     create_global_app()
 
-    atexit.register(on_exit)
+    # atexit.register(on_exit)
 
 
 def unregister():
@@ -129,14 +129,16 @@ def unregister():
 
     if not os.getenv("BQT_DISABLE_WRAP", 0) == "1":
         bpy.utils.unregister_class(bqt.focus.QFocusOperator)
-    atexit.unregister(on_exit)
+    # atexit.unregister(on_exit)
 
 
-def on_exit():
-    """Close BlenderApplication instance on exit"""
-    app = QApplication.instance()
-    if app:
-        app.store_window_geometry()
-        app.quit()
+# todo this doesnt work, likely becayse of the ACCESS_VIOLATION
+# def on_exit():
+#     """Close BlenderApplication instance on exit"""
+#     print("bqt: on_exit")
+#     app = QApplication.instance()
+#     if app:
+#         app.store_window_geometry()
+#         app.quit()
 
 

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -151,6 +151,10 @@ class BlenderApplication(QApplication):
             # if this is successful, blender will trigger bqt.on_exit()
             event.ignore()
 
+            # todo - this is a hack to get around the fact that the close event is not being triggered
+            # the only drawback is we now save geo even if user cancels the close dialogue
+            self.store_window_geometry()  # this should trigger on_exit(), but atm on_exit() is not being triggered
+
             if os.getenv("BQT_DISABLE_CLOSE_DIALOGUE") == "1":
                 # this triggers the default blender close event, showing the save dialog if needed
                 bpy.ops.wm.quit_blender({"window": bpy.context.window_manager.windows[0]}, "INVOKE_DEFAULT")

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -148,12 +148,9 @@ class BlenderApplication(QApplication):
         if isinstance(event, QCloseEvent) and receiver in (self.blender_widget, self._blender_window):
             # catch the close event when clicking close on the qt window,
             # ignore the event, and ask user if they want to close blender if unsaved changes.
-            # if this is successful, blender will trigger bqt.on_exit()
             event.ignore()
 
-            # todo - this is a hack to get around the fact that the close event is not being triggered
-            # the only drawback is we now save geo even if user cancels the close dialogue
-            self.store_window_geometry()  # this should trigger on_exit(), but atm on_exit() is not being triggered
+            self.store_window_geometry()  # save qt window geometry, to restore on next launch
 
             if os.getenv("BQT_DISABLE_CLOSE_DIALOGUE") == "1":
                 # this triggers the default blender close event, showing the save dialog if needed

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -14,9 +14,10 @@ from bqt.ui.quit_dialogue import BlenderClosingDialog
 import bpy
 
 
-STYLESHEET_FILEPATH = Path(__file__).parents[1] / "blender_stylesheet.qss"
-ORG = "Tech-Artists.org"
+STYLESHEET_PATH = Path(__file__).parents[1] / "blender_stylesheet.qss"
+ORGANISATION = "Tech-Artists.org"
 APP = "Blender Qt"
+WINDOW_TITLE = "Blender Qt"
 WINDOW_GROUP_NAME = "MainWindow"
 GEOMETRY = "Geometry"
 MAXIMIZED = "IsMaximized"
@@ -32,9 +33,8 @@ class BlenderApplication(QApplication):
         __metaclass__ = ABCMeta
         super().__init__(*args, **kwargs)
 
-        # QApplication
-        if self._stylesheet_filepath.exists():
-            self.setStyleSheet(self._stylesheet_filepath.read_text())
+        if STYLESHEET_PATH.exists():
+            self.setStyleSheet(STYLESHEET_PATH.read_text())
 
         QApplication.setWindowIcon(self._get_application_icon())
 
@@ -114,7 +114,7 @@ class BlenderApplication(QApplication):
         .setGeometry() sets the size of the window minus the window frame.
         For this reason it should be set on self.blender_widget.
         """
-        settings = QSettings(ORG, APP)
+        settings = QSettings(ORGANISATION, APP)
         settings.beginGroup(WINDOW_GROUP_NAME)
         fullscreen = settings.value(FULL_SCREEN, defaultValue=False, type=bool)
         maximized = settings.value(MAXIMIZED, defaultValue=False, type=bool)
@@ -169,7 +169,7 @@ class BlenderApplication(QApplication):
         For that reason the _blender_widget should be used.
         """
 
-        settings = QSettings(ORG, APP)
+        settings = QSettings(ORGANISATION, APP)
         settings.beginGroup(WINDOW_GROUP_NAME)
         settings.setValue(GEOMETRY, self.blender_widget.geometry())
         settings.setValue(MAXIMIZED, self.blender_widget.isMaximized())


### PR DESCRIPTION
- window now correctly remembers size, position, fullscreen, maximised state from previous session. 
this was currently prevented by the crash on exit.  https://github.com/techartorg/bqt/issues/47
    - removed `atexit` module and `on_exit` method. since we could simplify the code
    - did not solve the crash on exit, for further debate on this see above linked issue
- window now maintains the dimensions of the unwrapped blender window, if it was never wrapped before
solving https://github.com/techartorg/bqt/issues/72
- refactored some docstrings and constants

note
- full screen or maximised state are not yet passed on first time wrap.
seems overkill but we could always add it.
