### PR TITLE
Auto discover widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ mklink /J "C:\Users\USERNAME\AppData\Roaming\Blender Foundation\Blender\2.93\scr
 |BQT_DISABLE_WRAP| if set to `1`, disable wrapping blender in a QWindow|
 |BQT_DISABLE_CLOSE_DIALOGUE| if set to `1`, use the standard blender close dialogue|
 |BQT_MANAGE_FOREGROUND| defaults to `1`, if `0`, widgets registered with `bqt.add(my_widget)` won't stay in the foreground when using Blender.|
+|BQT_AUTO_ADD| defaults to `1`, if `0` top level widgets won't automatically be added to bqt.|
 
 - if you modify env vars, ensure they're strings
 - if you're unsure how to set env vars, google `set environment variable windows`.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ mklink /J "C:\Users\USERNAME\AppData\Roaming\Blender Foundation\Blender\2.93\scr
 ```
 
 ### Environment variables
+
 | variable | description|
 |--|--|
 |BQT_DISABLE_STARTUP| if set to `1`, completely disable bqt|
 |BQT_DISABLE_WRAP| if set to `1`, disable wrapping blender in a QWindow|
 |BQT_DISABLE_CLOSE_DIALOGUE| if set to `1`, use the standard blender close dialogue|
 |BQT_MANAGE_FOREGROUND| defaults to `1`, if `0`, widgets registered with `bqt.add(my_widget)` won't stay in the foreground when using Blender.|
-if you modify env vars, ensure they're strings
+
+- if you modify env vars, ensure they're strings
+- if you're unsure how to set env vars, google `set environment variable windows`.
+- Restart Blender (or your computer) after changing them.
 
 ### Sample code
 [bqt_demo](bqt_demo) shows you how to use bqt with several qt demos you can run in Blender
@@ -70,5 +74,5 @@ Discuss BQT on
 - the BlenderArtists [thread](https://blenderartists.org/t/bqt-custom-ui-for-add-ons-tool-in-blender-with-pyqt-or-pyside/1458808)
 - [Ynput  thread](https://community.ynput.io/t/use-bqt-for-blender-qt-integration/127)
 
-### ALternative
+### Alternative
 - Custom UI for Blender only: https://github.com/mmmrqs/bl_ui_widgets

--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -5,6 +5,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
 import bqt
 import bqt.focus
+import bqt.widget_manager
 import os
 import sys
 import bpy
@@ -29,6 +30,7 @@ bl_info = {
         "category": "UI"
         }
 
+add = bqt.widget_manager.add
 
 # CORE FUNCTIONS #
 

--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -30,7 +30,7 @@ bl_info = {
         "category": "UI"
         }
 
-add = bqt.widget_manager.add
+register = bqt.widget_manager.register
 
 # CORE FUNCTIONS #
 

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -46,6 +46,8 @@ class BlenderApplication(QApplication):
         self._hwnd = self._get_blender_hwnd()
         failed_to_get_handle = self._hwnd is None
 
+        self.window_container: QWidget = None
+
         if os.getenv("BQT_DISABLE_WRAP") == "1" or failed_to_get_handle:
             self._blender_window = QWindow()
             self.blender_widget = QWidget.createWindowContainer(self._blender_window)
@@ -71,6 +73,8 @@ class BlenderApplication(QApplication):
         # we only need foreground managing if blender is not wrapped
         if os.getenv("BQT_DISABLE_WRAP") == "1" and os.getenv("BQT_MANAGE_FOREGROUND", "1") == "1" and self.blender_focus_toggled():
             bqt.widget_manager._blender_window_change(self._active_window_hwnd)
+
+        bqt.widget_manager.parent_orphan_widgets(exclude=[self.blender_widget, self._blender_window, self.window_container])  # auto parent any orphaned widgets
 
     def blender_focus_toggled(self):
         """returns true the first frame the blender window is focussed or unfoccused"""

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -60,12 +60,14 @@ class BlenderApplication(QApplication):
             self.blender_widget.show()
             self.focusObjectChanged.connect(self._on_focus_object_changed)
 
+        # hookup event loop
         self.timer = QTimer()
         self.timer.timeout.connect(self.on_update)
         tick = int(1000 / FOCUS_FRAMERATE)  # tick 1000 / frames per second
         self.timer.start(tick)
 
     def on_update(self):
+        """qt event loop"""
         # we only need foreground managing if blender is not wrapped
         if os.getenv("BQT_DISABLE_WRAP") == "1" and os.getenv("BQT_MANAGE_FOREGROUND", "1") == "1" and self.blender_focus_toggled():
             bqt.widget_manager._blender_window_change(self._active_window_hwnd)

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -74,7 +74,8 @@ class BlenderApplication(QApplication):
         if os.getenv("BQT_DISABLE_WRAP") == "1" and os.getenv("BQT_MANAGE_FOREGROUND", "1") == "1" and self.blender_focus_toggled():
             bqt.widget_manager._blender_window_change(self._active_window_hwnd)
 
-        bqt.widget_manager.parent_orphan_widgets(exclude=[self.blender_widget, self._blender_window, self.window_container])  # auto parent any orphaned widgets
+        if os.getenv("BQT_AUTO_ADD", "1") == "1":
+            bqt.widget_manager.parent_orphan_widgets(exclude=[self.blender_widget, self._blender_window, self.window_container])  # auto parent any orphaned widgets
 
     def blender_focus_toggled(self):
         """returns true the first frame the blender window is focussed or unfoccused"""

--- a/bqt/widget_manager.py
+++ b/bqt/widget_manager.py
@@ -18,13 +18,14 @@ class WidgetData():
         self.visible = visible
 
 
-def add(widget, exclude=None, parent=None):
+def register(widget, exclude=None, parent=True, manage=True):
     """
     parent widget to blender window
     Args:
         widget: child widget to parent
-        parent: parent widget to parent the child widget to
+        parent: if True, parent the widget to the blender window
         exclude: widgets to exclude from being parented to the blender window
+        manage: if True, manage the visibility of the widget
     """
     exclude = exclude or []
 
@@ -32,8 +33,8 @@ def add(widget, exclude=None, parent=None):
         logging.warning("bqt: widget is None, skipping widget registration")
         return
 
-    parent = parent or QApplication.instance().blender_widget
-    if widget == parent:
+    parent_widget = QApplication.instance().blender_widget
+    if widget == parent_widget:
         return
 
     if widget in exclude:
@@ -41,13 +42,13 @@ def add(widget, exclude=None, parent=None):
         return
 
     # parent to blender window
-    widget.setParent(parent, Qt.Window)  # default set flag to window
+    if parent:
+        widget.setParent(parent_widget, Qt.Window)  # default set flag to window
 
     # save widget so we can manage the focus and visibility
-    data = WidgetData(widget, widget.isVisible())  # todo can we init vis state to false?
-    __widgets.append(data)
-
-    print(f"bqt: added widget {widget} to blender window {parent}")
+    if manage:
+        data = WidgetData(widget, widget.isVisible())  # todo can we init vis state to false?
+        __widgets.append(data)
 
 
 def iter_widget_data():
@@ -103,4 +104,4 @@ def parent_orphan_widgets(exclude=None):
     """Find and parent orphan widgets to the blender widget"""
     exclude = exclude or []
     for widget in _orphan_toplevel_widgets():
-        add(widget, exclude=exclude)
+        register(widget, exclude=exclude)

--- a/bqt/widget_manager.py
+++ b/bqt/widget_manager.py
@@ -76,3 +76,14 @@ def _blender_window_change(hwnd: int):
 
     # todo right now widgets stay in front of other blender windows,
     #  e.g. the preferences window, ideally we handle this
+
+
+def _orphan_toplevel_widgets():
+    # todo do we need to filter by window type?
+    return [widget for widget in QApplication.instance().topLevelWidgets() if not widget.parent()]
+
+
+def parent_orphan_widgets():
+    """Find and parent orphan widgets to the blender widget"""
+    for widget in _orphan_toplevel_widgets():
+        add(widget)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class CustomInstall(install):
 setup(
     # Metadata
     name="bqt",
-    version="1.1.0",
+    version="1.2.0",
     description="Files to help bootstrap PySide2 with an event loop within Blender.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
auto discover top level widgets with no parent, and add them to our bqt manager

devs can just run simple code (native qt, no bqt code needed)
```python
from PySide2.QtWidgets import QWidget
w = QWidget()
w.show()
```

no need to run the add command anymore
```python
import bqt
bqt.register(w)
```

### garbage collect note
- if you run above code in the script-editor the widget will instantly be garbage collected, since this happens so fast there is no time to discover it.
- if you run above code in the terminal then the widget stays in memory since it's saved in the variable `w` in the current session

so depending on your implementation it still might be easier to use `bqt.register`

If this feature causes issues, it can be disabled with the env var `BQT_AUTO_ADD` set to `0`
