### PR TITLE
Remove hardlink for requirements and replace it with function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ class CustomInstall(install):
         # Run the standard PyPi Copy
         install.run(self)
 
+def read_requirements():
+    with open('requirements.txt') as reqs:
+        return reqs.read().splitlines()
+
 
 setup(
     # Metadata

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     # Requirements
     python_requires=">=3.7",
     packages=["bqt"],
-    install_requires=["PySide6", "blender-qt-stylesheet"],
+    install_requires=read_requirements(),
     # Package Data
     include_package_data=True,
     package_data={"bqt": ["*.png", "*.qss"]},


### PR DESCRIPTION
This fix adds a function to read `requirements.txt` and uses it remove hardlinking the setup requirements as mentioned in issue #119 
