### PR TITLE
Fix BQT_DISABLE_CLOSE_DIALOGUE

### DIFF
--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -192,7 +192,8 @@ class BlenderApplication(QApplication):
 
             if os.getenv("BQT_DISABLE_CLOSE_DIALOGUE") == "1":
                 # this triggers the default blender close event, showing the save dialog if needed
-                bpy.ops.wm.quit_blender({"window": bpy.context.window_manager.windows[0]}, "INVOKE_DEFAULT")
+                with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+                    bpy.ops.wm.quit_blender("INVOKE_DEFAULT")
             else:
                 closing_dialog = BlenderClosingDialog(self.blender_widget)
                 closing_dialog.execute()

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -192,8 +192,11 @@ class BlenderApplication(QApplication):
 
             if os.getenv("BQT_DISABLE_CLOSE_DIALOGUE") == "1":
                 # this triggers the default blender close event, showing the save dialog if needed
-                with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
-                    bpy.ops.wm.quit_blender("INVOKE_DEFAULT")
+                if bpy.app.version >= (4, 0, 0):
+                    with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+                        bpy.ops.wm.quit_blender("INVOKE_DEFAULT")
+                else:
+                    bpy.ops.wm.quit_blender({"window": bpy.context.window_manager.windows[0]}, "INVOKE_DEFAULT")
             else:
                 closing_dialog = BlenderClosingDialog(self.blender_widget)
                 closing_dialog.execute()


### PR DESCRIPTION
Fix BQT_DISABLE_CLOSE_DIALOGUE
From Blender 4.0 onwards, overriding context directly on methods is disabled, and `bpy.context.temp_override()` is to be used instead.

The error was:

    ValueError: Error calling Python override of QApplication::notify(): 1-2 args execution context is supported