### PR TITLE
compatibility fix for overriding context

### DIFF
--- a/bqt/ui/quit_dialogue.py
+++ b/bqt/ui/quit_dialogue.py
@@ -28,13 +28,19 @@ class WINDOW_OT_SaveFileFromQt(bpy.types.Operator):
     bl_label = "Save_from_Qt"
 
     def execute(self, context):
+
+        # context override is needed, without a UI, the operators are likely to fail/ no dialogue shows.
         with bpy.context.temp_override(window=bpy.context.window_manager.windows[0]):
+            
+            # EXEC_AREA = run the operator directly, saves without dialogue
+            # INVOKE_AREA = behave like a user clicked File → Save, show file browser
             if context.blend_data.is_saved:
-                # Operator needs to be invoked different depending on if
-                # the blender file has been saved before or is "untitled".
+                # save file
                 bpy.ops.wm.save_mainfile('EXEC_AREA', check_existing=False)
             else:
+                # ask user where to save the file
                 bpy.ops.wm.save_mainfile('INVOKE_AREA', check_existing=False)
+                
         return {'FINISHED'}
 
 # todo


### PR DESCRIPTION
Quitting with unsaved changes causes crash in 4.0 and higher.