### PR TITLE
Set fusion style to mimic os style

### DIFF
--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -55,6 +55,8 @@ def _load_os_module() -> "bqt.blender_applications.BlenderApplication":
     if operating_system == "darwin":
         from .blender_applications.darwin_blender_application import DarwinBlenderApplication
 
+        DarwinBlenderApplication.setStyle("Fusion")
+
         return DarwinBlenderApplication(sys.argv)
 
     elif operating_system in ["linux", "linux2"]:
@@ -65,7 +67,9 @@ def _load_os_module() -> "bqt.blender_applications.BlenderApplication":
     elif operating_system == "win32":
         from .blender_applications.win32_blender_application import Win32BlenderApplication
 
-        return Win32BlenderApplication(sys.argv + ['-platform', 'windows:darkmode=2'])
+        Win32BlenderApplication.setStyle("Fusion")
+
+        return Win32BlenderApplication(sys.argv)
 
     else:
         raise OSError(f"OS module for '{operating_system}' not found")


### PR DESCRIPTION
Sets the BQT Application to use the [fusion theme](https://doc.qt.io/qtforpython-6/overviews/qtquickcontrols-fusion.html), to mimic normal title bar behavior

This sets it on both Mac and Windows. But I don't have mac so it is untested on that platform.

(Screenshots has a browser behind blender to highlight theme switching)

# Non-BQT Blender
Windows set to a Light mode
<img width="421" height="189" alt="image" src="https://github.com/user-attachments/assets/d470f0c2-0263-4478-a854-1766be0c9145" />

Windows set to a dark mode
<img width="449" height="163" alt="image" src="https://github.com/user-attachments/assets/187d18c3-7b8f-45e7-a1e7-3ea1c140b160" />

# Current BQT Blender
Windows set to a dark mode, title bar is still light
<img width="515" height="142" alt="image" src="https://github.com/user-attachments/assets/7e290d1d-3ec7-40f9-8d6e-2ac40565e31c" />


# After PR
Windows set to a light mode
<img width="420" height="149" alt="image" src="https://github.com/user-attachments/assets/e2bd62f7-c34a-4aa7-aada-91f1369e778c" />


Windows set to a dark mode
<img width="428" height="149" alt="image" src="https://github.com/user-attachments/assets/77d547a4-b089-416a-a87b-c14405af6a06" />

