### PR TITLE
Remove metaclass usage

### DIFF
--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -6,7 +6,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import os
 import logging
 from pathlib import Path
-from abc import abstractmethod, abstractstaticmethod, ABCMeta
+from abc import abstractmethod, ABCMeta
 
 from PySide6.QtCore import QEvent, QObject, QRect, QSettings, QTimer
 from PySide6.QtWidgets import QApplication, QWidget, QMainWindow
@@ -31,13 +31,12 @@ FULL_SCREEN = "IsFullScreen"
 FOCUS_FRAMERATE = 15
 
 
-class BlenderApplication(QApplication):
+class BlenderApplication(QApplication, metaclass=ABCMeta):
     """
     Base Implementation for QT Blender Window Container
     """
 
     def __init__(self, *args, **kwargs):
-        __metaclass__ = ABCMeta
         super().__init__(*args, **kwargs)
 
         logger.debug("initializing BlenderApplication")
@@ -141,12 +140,14 @@ class BlenderApplication(QApplication):
     def _focus_window():
         pass
 
-    @abstractstaticmethod
+    @staticmethod
+    @abstractmethod
     def _get_blender_hwnd() -> int:
         """Get the handler window ID for the blender application window"""
         return -1
 
     @staticmethod
+    @abstractmethod
     def _get_application_icon() -> QIcon:
         """
         This finds the running blender process, extracts the blender icon from the blender.exe file on disk and saves it to the user's temp folder.

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -6,7 +6,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import os
 import logging
 from pathlib import Path
-from abc import abstractmethod, ABCMeta
 
 from PySide6.QtCore import QEvent, QObject, QRect, QSettings, QTimer
 from PySide6.QtWidgets import QApplication, QWidget, QMainWindow
@@ -31,7 +30,7 @@ FULL_SCREEN = "IsFullScreen"
 FOCUS_FRAMERATE = 15
 
 
-class BlenderApplication(QApplication, metaclass=ABCMeta):
+class BlenderApplication(QApplication):
     """
     Base Implementation for QT Blender Window Container
     """
@@ -141,13 +140,11 @@ class BlenderApplication(QApplication, metaclass=ABCMeta):
         pass
 
     @staticmethod
-    @abstractmethod
     def _get_blender_hwnd() -> int:
         """Get the handler window ID for the blender application window"""
-        return -1
+        raise NotImplementedError
 
     @staticmethod
-    @abstractmethod
     def _get_application_icon() -> QIcon:
         """
         This finds the running blender process, extracts the blender icon from the blender.exe file on disk and saves it to the user's temp folder.
@@ -155,16 +152,14 @@ class BlenderApplication(QApplication, metaclass=ABCMeta):
 
         Returns QIcon: Application Icon
         """
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def _on_focus_object_changed(self, focus_object: QObject):
         """
         Args:
             focus_object: Object to track focus event
         """
-
-        pass
+        raise NotImplementedError
 
     def _unwrapped_window_geometry(self) -> QRect:
         """

--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -37,7 +37,7 @@ class BlenderApplication(QApplication):
     Base Implementation for QT Blender Window Container
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         logger.debug("initializing BlenderApplication")


### PR DESCRIPTION
"Fixed" how the metaclass is defined, and later used.

Using the `__metaclass__` is an old pattern. The keyword argument is standard in python 3