### PR TITLE
Patch for the Window menu to enable the Fullscreen button

### DIFF
--- a/bqt/__init__.py
+++ b/bqt/__init__.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 import logging
+import functools
 
 # add to sys path so we can import bqt
 current_dir = str(Path(__file__).parent.parent)
@@ -21,6 +22,7 @@ from PySide6.QtCore import Qt
 import bqt
 import bqt.focus
 import bqt.manager
+import bqt.ui.patches.menu
 
 logger = logging.getLogger("bqt")
 add = bqt.manager.register
@@ -75,13 +77,18 @@ def _load_os_module() -> "bqt.blender_applications.BlenderApplication":
         raise OSError(f"OS module for '{operating_system}' not found")
 
 
+@functools.cache
+def get_application() -> "bqt.blender_applications.BlenderApplication":
+    return _instantiate_q_application()
+
+
 @bpy.app.handlers.persistent
 def _create_global_app():
     """
     Create a global QApplication instance, that's maintained between Blender sessions.
     Runs after Blender finished startup.
     """
-    qapp = _instantiate_q_application()
+    qapp = get_application()
     # save a reference to the C++ window in a global var, to prevent the parent being garbage collected
     # for some reason this works here, but not in the blender_applications init as a class attribute (self),
     # and saving it in a global in blender_applications.py causes blender to crash on startup
@@ -114,6 +121,11 @@ def register():
     """
     setup_logger()
     logger.debug("registering bqt add-on")
+
+    if os.getenv("BQT_DISABLE_WRAP", None) != "1":
+        # Patch the gui if we are wrapping
+        bqt.ui.patches.menu.register()
+
     # hacky way to check if we already are waiting on bqt setup, or bqt is already setup
     if QApplication.instance():
         logger.warning("QApplication already exists, skipping bqt registration")

--- a/bqt/ui/patches/menu.py
+++ b/bqt/ui/patches/menu.py
@@ -1,0 +1,82 @@
+import bpy
+from bl_ui import space_topbar
+
+
+class FullscreenOperator(bpy.types.Operator):
+    bl_idname = "wm.window_fullscreen_qt_toggle"
+    bl_label = "Toggle Window Fullscreen"
+    bl_description = "Toggle the current window full-screen"
+
+    def execute(self, context):
+        from bqt import get_application
+        app = get_application()
+        if app.blender_widget.isFullScreen():
+            app.blender_widget.showNormal()
+        else:
+            app.blender_widget.showFullScreen()
+        return {"FINISHED"}
+
+
+class TOPBAR_MT_window(bpy.types.Menu):
+    """Copied from Blender 5.0.0
+
+    scripts/startup/bl_ui/space_topbar.py
+    """
+
+
+    bl_label = "Window"
+
+    def draw(self, context):
+        import sys
+        from _bl_ui_utils.layout import operator_context
+
+        layout = self.layout
+
+        layout.operator("wm.window_new")
+        layout.operator("wm.window_new_main")
+
+        layout.separator()
+
+        # Changed from shipped menu.
+        layout.operator("wm.window_fullscreen_qt_toggle", icon='FULLSCREEN_ENTER')
+
+        layout.separator()
+
+        layout.operator("screen.workspace_cycle", text="Next Workspace").direction = 'NEXT'
+        layout.operator("screen.workspace_cycle", text="Previous Workspace").direction = 'PREV'
+
+        layout.separator()
+
+        layout.prop(context.screen, "show_statusbar")
+
+        layout.separator()
+
+        layout.operator("screen.screenshot")
+
+        # Showing the status in the area doesn't work well in this case.
+        # - From the top-bar, the text replaces the file-menu (not so bad but strange).
+        # - From menu-search it replaces the area that the user may want to screen-shot.
+        # Setting the context to screen causes the status to show in the global status-bar.
+        with operator_context(layout, 'INVOKE_SCREEN'):
+            layout.operator("screen.screenshot_area")
+
+        if sys.platform[:3] == "win":
+            layout.separator()
+            layout.operator("wm.console_toggle", icon='CONSOLE')
+
+        if context.scene.render.use_multiview:
+            layout.separator()
+            layout.operator("wm.set_stereo_3d")
+
+
+
+def register():
+    bpy.utils.unregister_class(space_topbar.TOPBAR_MT_window)
+    bpy.utils.register_class(FullscreenOperator)
+    bpy.utils.register_class(TOPBAR_MT_window)
+
+
+def unregister():
+    bpy.utils.register_class(space_topbar.TOPBAR_MT_window)
+    bpy.utils.unregister_class(FullscreenOperator)
+    bpy.utils.unregister_class(TOPBAR_MT_window)


### PR DESCRIPTION
In theory fixes https://github.com/techartorg/bqt/issues/3

This is a bit tricky to fix in a good way, and we _really_ need to consider if we need this kind of complexity. It wouldn't surprise me if there are other locations that needs similar fixes.

How this is fixed here is by finding the current "Window" menu and unregistering the class. We then register our custom menu class that has the same class name. This overwrites the menu.

As we need to fully replace the menu this adds complexity as if Blender adds a or removes from the menu our own menu will get out dated.

**What do you think @hannesdelbeke, is this complexity really worth it?** I am on the fence, feels excessive to me.

p.s.
_This does not resolve that any fullscreen hotkey might not work._

## Other ways I tried.

### Register a new operator with the same name.
Since Blender 3.5 this is no longer possible and doing it raises an error.

### Unregister the current operator.
It's impossible to unregister builtin (c++) operators.


___

I did ask about this as a [Blender Bug](https://projects.blender.org/blender/blender/issues/155241) and did request a feature to easier overwrite existing operators on [rightclickselect](https://blender.community/c/rightclickselect/lDn7)