### PR TITLE
exclude None-objects from parenting logic

### DIFF
--- a/bqt/blender_applications/blender_application.py
+++ b/bqt/blender_applications/blender_application.py
@@ -118,7 +118,8 @@ class BlenderApplication(QApplication):
             bqt.manager._blender_window_change(self._active_window_hwnd)
 
         if os.getenv("BQT_AUTO_ADD", "1") == "1":
-            bqt.manager.parent_orphan_widgets(exclude=[self.blender_widget, self._blender_window, self.window_container])  # auto parent any orphaned widgets
+            excluded_objects = [self.blender_widget, self._blender_window, self.window_container]
+            bqt.manager.parent_orphan_widgets(exclude=[obj for obj in excluded_objects if obj])  # auto parent any orphaned widgets
 
     def blender_focus_toggled(self) -> bool:
         """returns true the first frame the blender window is focussed or unfoccused"""

--- a/bqt/manager.py
+++ b/bqt/manager.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("bqt")
 
 __widgets: list[WidgetData] = []
-__excluded_widgets: WeakSet[QWindow | QWidget | None] = WeakSet()
+__excluded_widgets: WeakSet[QWindow | QWidget] = WeakSet()
 
 
 class WidgetData:
@@ -62,7 +62,7 @@ def make_widget_dockable(widget) -> QWidget:
 
 def register(
         widget: QWidget,
-        exclude: list[QWindow | QWidget | None] | None = None,
+        exclude: list[QWindow | QWidget] | None = None,
         parent: bool = True,
         manage: bool = True,
         unique: bool = True
@@ -191,7 +191,7 @@ def _orphan_toplevel_widgets() -> list[QWidget]:
             and widget not in __excluded_widgets]
 
 
-def parent_orphan_widgets(exclude: list[QWindow | QWidget | None] | None = None) -> None:
+def parent_orphan_widgets(exclude: list[QWindow | QWidget] | None = None) -> None:
     """Find and parent orphan widgets to the blender widget"""
     # this runs every frame, don't print or log in this method
     exclude = exclude or []


### PR DESCRIPTION
This is needed as Weakref can't take None objects.